### PR TITLE
Add tests and extra logging

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -44,6 +44,17 @@ module.exports = NodeHelper.create({
                           },
                           body: JSON.stringify(dest.body)
                         }, function(error, response, body) {
+        console.log("Request URL: " + dest.url);
+        console.log("Request Body: " + JSON.stringify(dest.body));
+        if (error) {
+          console.error("Request Error:", error);
+        }
+        if (response) {
+          console.log("Response Status Code:", response.statusCode);
+        }
+        if (body) {
+          console.log("Response Body:", body);
+        }
 				
         var prediction = new Object({
           config: dest.config

--- a/package.json
+++ b/package.json
@@ -23,5 +23,12 @@
     "moment": "^2.18.1",
     "moment-duration-format": "^1.3.0",
     "request": "^2.81.0"
+  },
+  "devDependencies": {
+    "mocha": "^10.0.0",
+    "nock": "^13.0.0"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,25 @@
+const request = require('request');
+const nock = require('nock');
+const assert = require('assert');
+
+describe('Google Routes API', function() {
+  it('returns 403 error', function(done) {
+    const scope = nock('https://routes.googleapis.com')
+      .post('/directions/v2:computeRoutes')
+      .reply(403, { error: 'forbidden' });
+
+    request({
+      url: 'https://routes.googleapis.com/directions/v2:computeRoutes?key=BAD',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Goog-FieldMask': 'routes.duration,routes.legs.duration,routes.legs.staticDuration,routes.legs.steps'
+      },
+      body: JSON.stringify({})
+    }, function(err, response, body) {
+      assert.strictEqual(response.statusCode, 403);
+      scope.done();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- log request/response details in `node_helper.js`
- add a mocha/nock test that simulates a 403 response from the Google Routes API
- add dev dependencies for mocha and nock

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a5898824832c98922c2a7d060ccd