### PR TITLE
Fix departureTime request timestamp

### DIFF
--- a/MMM-MyCommute.js
+++ b/MMM-MyCommute.js
@@ -219,7 +219,7 @@ Module.register('MMM-MyCommute', {
       origin: { address: this.config.origin },
       destination: { address: dest.destination },
       routingPreference: 'TRAFFIC_AWARE',
-      departureTime: new Date().toISOString()
+      departureTime: new Date(Date.now() + 60000).toISOString()
     };
 
     var mode = 'DRIVE';


### PR DESCRIPTION
## Summary
- ensure Google Routes API requests use a future `departureTime`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a9a8a460832ca2b16ae57a7ab38c