### PR TITLE
Fix routingPreference for transit mode

### DIFF
--- a/MMM-MyCommute.js
+++ b/MMM-MyCommute.js
@@ -246,7 +246,6 @@ Module.register('MMM-MyCommute', {
     var body = {
       origin: { address: originOverride || this.config.origin },
       destination: { address: dest.destination },
-      routingPreference: 'TRAFFIC_AWARE',
       departureTime: new Date(Date.now() + 60000).toISOString()
     };
 
@@ -258,6 +257,10 @@ Module.register('MMM-MyCommute', {
       dest.transitMode = dest.mode;
     }
     body.travelMode = mode;
+
+    if (mode !== 'TRANSIT') {
+      body.routingPreference = 'TRAFFIC_AWARE';
+    }
 
     if (dest.transitMode) {
       body.transitPreferences = { allowedTravelModes: dest.transitMode.split('|').map(function(m){ return m.toUpperCase(); }) };


### PR DESCRIPTION
## Summary
- don't include `routingPreference` when requesting transit directions

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843b1d7c1ec832cb77df07722ef04c4