### PR TITLE
Add commute time storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Each object in the `destinations` array can have the following parameters:
       <td><code>hideDays</code></td>
       <td>A list of numbers representing days of the week to hide the destination.<br><br><strong>Type:</strong> <code>array</code><br>Valid numbers are 0 through 6, 0 = Sunday, 6 = Saturday.<br>e.g.: <code>[0,6]</code> hides the destination on weekends.</td>
     </tr>
+    <tr>
+      <td><code>time</code></td>
+      <td>The last calculated travel time in seconds. This value is populated by the module and can be used by other modules.</td>
+    </tr>
 
   </tbody>
 </table>

--- a/node_helper.js
+++ b/node_helper.js
@@ -128,6 +128,10 @@ module.exports = NodeHelper.create({
             }
             prediction.routes = routeList;
 
+            if (routeList.length > 0) {
+              dest.config.time = routeList[0].timeInTraffic || routeList[0].time;
+            }
+
           }
 
         } else {
@@ -169,6 +173,7 @@ module.exports = NodeHelper.create({
                             transitInfo: allTransitInfo.length > 0 ? allTransitInfo : null
                         }]
                     };
+                    dest.config.time = totalTimeInTraffic > 0 ? totalTimeInTraffic : totalTime;
                     callback(prediction);
                     return;
                 }

--- a/test/multileg.test.js
+++ b/test/multileg.test.js
@@ -39,6 +39,7 @@ describe('Multi leg prediction', function() {
 
     helper.getMultiLegPrediction(dest, prediction => {
       assert.strictEqual(prediction.routes[0].time, 30);
+      assert.strictEqual(dest.config.time, 30);
       scope.done();
       done();
     });

--- a/test/singleleg.test.js
+++ b/test/singleleg.test.js
@@ -1,0 +1,36 @@
+const nock = require('nock');
+const assert = require('assert');
+const Module = require('module');
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === 'node_helper') {
+    return { create: obj => obj };
+  }
+  return originalLoad(request, parent, isMain);
+};
+const helper = require('../node_helper.js');
+Module._load = originalLoad;
+
+describe('Single leg prediction', function() {
+  it('sets time on destination config', function(done) {
+    const dest = {
+      url: 'https://routes.googleapis.com/directions/v2:computeRoutes',
+      body: {},
+      config: { label: 'Test' }
+    };
+
+    const scope = nock('https://routes.googleapis.com')
+      .post('/directions/v2:computeRoutes')
+      .reply(200, { routes: [{ summary: 'leg', legs: [{ duration: '15s', staticDuration: '15s' }] }] });
+
+    helper.sendSocketNotification = function(notification, payload) {
+      assert.strictEqual(payload[0].routes[0].time, 15);
+      assert.strictEqual(dest.config.time, 15);
+      scope.done();
+      done();
+    };
+
+    helper.getPredictions({ destinations: [{ url: dest.url, body: dest.body, config: dest.config }], instanceId: '1' });
+  });
+});


### PR DESCRIPTION
## Summary
- save predicted travel time into each destination's config
- expose `time` field in README
- test that time is set for single and multi-leg routes

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843bb8e3bc0832c837917e6a40525ba